### PR TITLE
Close neofsharp_nvimtree autocmd group

### DIFF
--- a/plugin/neofsharp.vim
+++ b/plugin/neofsharp.vim
@@ -10,6 +10,3 @@ augroup neofsharp_nvimtree
     au Filetype fsproj nmap <buffer> <silent> K 0f"lvi":call investigate#Investigate('v')<CR>
     au Filetype fsproj vmap <buffer> <silent> K :call investigate#Investigate('v')<CR>
 augroup
-
-
-

--- a/plugin/neofsharp.vim
+++ b/plugin/neofsharp.vim
@@ -9,4 +9,4 @@ augroup neofsharp_nvimtree
     au!
     au Filetype fsproj nmap <buffer> <silent> K 0f"lvi":call investigate#Investigate('v')<CR>
     au Filetype fsproj vmap <buffer> <silent> K :call investigate#Investigate('v')<CR>
-augroup
+augroup END


### PR DESCRIPTION
The `neofsharp_nvimtree` autocmd group is not properly closed, causing (through `:augroup` without parameter) a list of defined autocmds to be shown when starting (Neo)vim.